### PR TITLE
Added nuget.config

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
There is a bug or something related to the cached state of the windows action VM that causes dotnet restore to occasionally fail

More information available at actions/virtual-environments#3038